### PR TITLE
Fix the issue when cloning an url like ssh://git@my.git.server

### DIFF
--- a/src/main/scala/com/francoiscabrol/gitmaster/git/GitCmd.scala
+++ b/src/main/scala/com/francoiscabrol/gitmaster/git/GitCmd.scala
@@ -30,10 +30,7 @@ object GitCmd {
     case _ => GitStatus.UNEXPECTED_ERROR
   }
   def pull(dir: File):String = run(Process("git pull", dir))
-  def remoteUrl(dir: File):String = run(Process("git remote show origin", dir)).split(" ").find((str) => str.contains(".git") || str.contains("http")) match {
-    case Some(url) => url
-    case None => throw new GitCmdError("Impossible to parse the remote url of " + dir.getName)
-  }
+  def remoteUrl(dir: File):String = run(Process("git remote get-url origin", dir))
   def clone(url: String, branch: String):String = run(Process("git clone -b " + branch + " " + url))
   def clone(url: String):String = run(Process("git clone " + url))
   def cloneTo(url: String, dest: String):String = run(Process(s"git clone $url $dest"))

--- a/src/main/scala/com/francoiscabrol/gitmaster/gmaster.scala
+++ b/src/main/scala/com/francoiscabrol/gitmaster/gmaster.scala
@@ -86,7 +86,6 @@ object Gmaster {
           infos.map(info => {
             info.getRemoteUrl match {
               case Success(url) => repositoryConfigs += RepositoryConfig(url, info.branch, info.relativePath(Dir.value))
-              case Failure(e:GitMasterError) => Out println "[WARNING] " + info.name + ": " + e.message
               case Failure(e) => Out println "[ERROR] " +  info.name + ": " + e.toString
             }
           })


### PR DESCRIPTION
Re-implement the GitCmd.remoteUrl method (use the correct git command instead of the ugly hack)

Fix #6 