### PR TITLE
Quickfix the gmaster status with new git output

### DIFF
--- a/src/main/scala/com/francoiscabrol/gitmaster/git/GitCmd.scala
+++ b/src/main/scala/com/francoiscabrol/gitmaster/git/GitCmd.scala
@@ -25,6 +25,7 @@ object GitCmd {
     case x if x.contains("to be committed") => GitStatus.CHANGES_TO_COMMIT
     case x if x.contains("not staged") => GitStatus.UNSTAGE_FILES
     case x if x.contains("up-to-date") => GitStatus.UP_TO_DATE
+    case x if x.contains("up to date") => GitStatus.UP_TO_DATE
     case x if x.contains("git pull") => GitStatus.NOT_SYNC
     case x if x.contains("nothing to commit") => GitStatus.NO_REMOTE
     case _ => GitStatus.UNEXPECTED_ERROR


### PR DESCRIPTION
#6 
Looks like the new version of git changed the output of `git status`...
I should not rely here on the human readable output of `git status`. It was a naive approach and the best solution seems to be to use the git command `git status --porcelain`. This refactored will be done in the future.

This pull request just do a quickfix to get `gmaster status` working again.